### PR TITLE
add flag to specify target addr in proxy-queue

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -87,6 +87,7 @@ var (
 
 	concurrencyQuantumOfTime = flag.Duration("concurrencyQuantumOfTime", 100*time.Millisecond, "")
 	concurrencyModel         = flag.String("concurrencyModel", string(v1alpha1.RevisionRequestConcurrencyModelMulti), "")
+	targetAddr				 = flag.String("targetAddr", "http://localhost:8080", "Address for the proxy target.")
 	singleConcurrencyBreaker = queue.NewBreaker(singleConcurrencyQueueDepth, 1)
 )
 
@@ -279,9 +280,9 @@ func main() {
 		zap.String(logkey.Revision, servingRevision),
 		zap.String(commonlogkey.Pod, podName))
 
-	target, err := url.Parse("http://localhost:8080")
+	target, err := url.Parse(*targetAddr)
 	if err != nil {
-		logger.Fatal("Failed to parse localhost url", zap.Error(err))
+		logger.Fatalf("Failed to parse target url: %s, error: %v", *targetAddr, zap.Error(err))
 	}
 
 	httpProxy = httputil.NewSingleHostReverseProxy(target)


### PR DESCRIPTION
## Proposed Changes

  * Add a new flag, `targetAddr`, to specify target address behind the proxy-queue. 
  * This is because currently we assume the proxy-queue and the target are running inside the same Pod, but in the future they may be in different pods (e.g. for handling insecure workload)